### PR TITLE
fix: replace Bitnami images with open Soldevelo equivalents

### DIFF
--- a/banking/transaction-monitor/kafka-broker/Dockerfile
+++ b/banking/transaction-monitor/kafka-broker/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 bitnami/kafka:3.9.0
+FROM --platform=linux/amd64 soldevelo/kafka:3.9.0
 
 USER root
 RUN apt upgrade

--- a/banking/transaction-monitor/topic-create/Dockerfile
+++ b/banking/transaction-monitor/topic-create/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 bitnami/kafka:3.4.0
+FROM --platform=linux/amd64 soldevelo/kafka:3.4.1
 
 # OpenJDK 11.0.6
 RUN java --version

--- a/telco/churn/kafka-broker/Dockerfile
+++ b/telco/churn/kafka-broker/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 bitnami/kafka:3.7.0
+FROM --platform=linux/amd64 soldevelo/kafka:3.7.1
 
 # OpenJDK 11.0.6
 RUN java --version

--- a/telco/churn/topic-create/Dockerfile
+++ b/telco/churn/topic-create/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 bitnami/kafka:3.4.0
+FROM --platform=linux/amd64 soldevelo/kafka:3.4.1
 
 # OpenJDK 11.0.6
 RUN java --version


### PR DESCRIPTION
## Fix: replace restricted Bitnami images

Since **August 28, 2025**, Bitnami distributes most container images only through paid VMware Tanzu subscriptions. Pulling them without a valid subscription may fail silently or return stale image layers, which is a supply-chain reliability concern.

This PR replaces every affected reference with the corresponding image from [SolDevelo/containers](https://github.com/SolDevelo/containers) - a community fork of `bitnami/containers` that publishes identical, freely accessible images to Docker Hub under the `soldevelo/` namespace.

No configuration changes beyond the image tag itself are required.

## Replaced references

- `bitnami/kafka:3.9.0` → [`soldevelo/kafka:3.9.0`](https://hub.docker.com/r/soldevelo/kafka)
- `bitnami/kafka:3.4.0` → [`soldevelo/kafka:3.4.1`](https://hub.docker.com/r/soldevelo/kafka)
- `bitnami/kafka:3.7.0` → [`soldevelo/kafka:3.7.1`](https://hub.docker.com/r/soldevelo/kafka)